### PR TITLE
Adding tiny fix, podman stop t0

### DIFF
--- a/memory-exhaustion/memory-exhaustion
+++ b/memory-exhaustion/memory-exhaustion
@@ -176,7 +176,7 @@ cleanup_nested_containers() {
     echo "INFO: Cleaning up nested containers"
     for i in $(seq 1 $NUMBER_OF_CONTAINERS); do
         local additional_container_name="${MEMORY_EXHAUSTION_BASE_CONTAINER_NAME}_nested_$i"
-        if podman exec "$MEMORY_EXHAUSTION_BASE_CONTAINER_NAME" podman stop "$additional_container_name" && podman exec "$MEMORY_EXHAUSTION_BASE_CONTAINER_NAME" podman rm "$additional_container_name" --force; then
+        if podman exec "$MEMORY_EXHAUSTION_BASE_CONTAINER_NAME" podman stop -t0 "$additional_container_name" && podman exec "$MEMORY_EXHAUSTION_BASE_CONTAINER_NAME" podman rm "$additional_container_name" --force; then
             echo "INFO: Nested container $additional_container_name stopped and removed successfully"
         else
             echo "ERROR: Failed to stop and remove nested container $additional_container_name"

--- a/tests/beakerlib/N-instances-podman-parallel/runtest.sh
+++ b/tests/beakerlib/N-instances-podman-parallel/runtest.sh
@@ -4,7 +4,7 @@
 
 # Include BeakerLib environment
 
-# shellcheck source=/usr/share/beakerlib/beakerlib.sh
+# shellcheck source=/dev/null
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 REPO="https://github.com/containers/engine-stressor"


### PR DESCRIPTION
Based, on errors received CI.

level=warning msg="StopSignal SIGTERM failed to stop container memory_eater_base_container_nested_4 in 10 seconds, resorting to SIGKILL"

Signed-off-by: Yariv Rachmani <yrachman@redhat.com>
